### PR TITLE
feat: Implement new curriculum structure

### DIFF
--- a/curriculum.html
+++ b/curriculum.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Curriculum - Learn German</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>German Language Curriculum</h1>
+    </header>
+
+    <main>
+        <p>This is the full curriculum for learning German. Start from the top and work your way down, or jump to any topic you'd like to review.</p>
+
+        <nav class="curriculum-nav">
+            <ul class="topic-list">
+                <li>
+                    <h3>To Start</h3>
+                    <ul>
+                        <li><a href="topics/greetings/index.html">Greetings</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <h3>Grammar</h3>
+                    <ul>
+                        <li><a href="topics/grammar/pronouns/index.html">Pronouns</a></li>
+                        <li><a href="topics/grammar/prepositions/index.html">Prepositions</a></li>
+                        <li><a href="topics/grammar/adjective/index.html">Adjective</a></li>
+                        <li><a href="topics/grammar/comparative-superlative/index.html">Comparative and superlative</a></li>
+                        <li><a href="topics/grammar/conjunctions/index.html">Conjunctions</a></li>
+                        <li><a href="topics/grammar/adverbs/index.html">Adverbs</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <h3>Sentences</h3>
+                    <ul>
+                        <li><a href="topics/sentences/sentence-structure/index.html">Sentence structure</a></li>
+                        <li><a href="topics/sentences/negation-affirmation/index.html">Negation and Affirmation</a></li>
+                        <li><a href="topics/sentences/interrogation/index.html">Interrogation</a></li>
+                        <li><a href="topics/sentences/relative-clauses/index.html">Relative Clauses</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <h3>Noun</h3>
+                    <ul>
+                        <li><a href="topics/noun/declension/index.html">Declension</a></li>
+                        <li><a href="topics/noun/masculine-gender/index.html">Masculine gender</a></li>
+                        <li><a href="topics/noun/feminine-gender/index.html">Feminine gender</a></li>
+                        <li><a href="topics/noun/neuter-gender/index.html">Neuter gender</a></li>
+                        <li><a href="topics/noun/plural/index.html">Plural</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <h3>Verb</h3>
+                    <ul>
+                        <li><a href="topics/verb/verb-conjugation/index.html">Verb conjugation</a></li>
+                        <li><a href="topics/verb/prasens/index.html">Präsens</a></li>
+                        <li><a href="topics/verb/perfekt/index.html">Perfekt</a></li>
+                        <li><a href="topics/verb/prateritum/index.html">Präteritum</a></li>
+                        <li><a href="topics/verb/plusquamperfekt/index.html">Plusquamperfekt</a></li>
+                        <li><a href="topics/verb/futur/index.html">Futur I and Futur II</a></li>
+                        <li><a href="topics/verb/konjunktiv-i/index.html">Konjunktiv I</a></li>
+                        <li><a href="topics/verb/konjunktiv-ii/index.html">Konjunktiv II</a></li>
+                        <li><a href="topics/verb/imperative/index.html">Imperative</a></li>
+                        <li><a href="topics/verb/passive/index.html">Passive</a></li>
+                        <li><a href="topics/verb/modal-verbs/index.html">Modal Verbs</a></li>
+                        <li><a href="topics/verb/reflexive-verbs/index.html">Reflexive verbs</a></li>
+                        <li><a href="topics/verb/irregular-verbs/index.html">Irregular verbs</a></li>
+                        <li><a href="topics/verb/separable-verbs/index.html">Separable Verbs</a></li>
+                        <li><a href="topics/verb/sein-haben-werden/index.html">sein, haben, werden</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <h3>Practical German</h3>
+                    <ul>
+                        <li><a href="topics/practical/du-sie-form/index.html">du/Sie form</a></li>
+                        <li><a href="topics/practical/time/index.html">Time</a></li>
+                        <li><a href="topics/practical/apostrophe/index.html">Apostrophe</a></li>
+                    </ul>
+                </li>
+                <li>
+                    <h3>Vocabulary</h3>
+                    <ul>
+                        <li><a href="topics/vocabulary/numbers/index.html">Numbers</a></li>
+                        <li><a href="topics/vocabulary/countries/index.html">Countries</a></li>
+                        <li><a href="topics/vocabulary/family/index.html">Family</a></li>
+                        <li><a href="topics/vocabulary/colors/index.html">Colors</a></li>
+                        <li><a href="topics/vocabulary/geography/index.html">Geography</a></li>
+                        <li><a href="topics/vocabulary/mathematics/index.html">Mathematics</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </nav>
+
+        <br>
+        <a href="index.html">Back to Home</a>
+    </main>
+
+    <footer>
+        <p>&copy; 2025 Learn German for Myanmar</p>
+    </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -130,3 +130,55 @@ hr {
 .card a:hover {
     color: var(--primary-color);
 }
+
+/* Call to Action Button */
+.cta-button {
+    display: inline-block;
+    background-color: var(--primary-color);
+    color: #fff;
+    padding: 1rem 2rem;
+    font-size: 1.2rem;
+    font-weight: 700;
+    border-radius: 8px;
+    text-align: center;
+    margin-top: 2rem;
+    transition: background-color 0.3s ease;
+}
+
+.cta-button:hover {
+    background-color: #7b5cbd; /* A slightly darker purple */
+    color: #fff;
+}
+
+/* Curriculum Navigation */
+.curriculum-nav .topic-list {
+    list-style: none;
+    padding: 0;
+}
+
+.curriculum-nav .topic-list h3 {
+    font-size: 1.5rem;
+    color: var(--primary-color);
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 0.5rem;
+}
+
+.curriculum-nav .topic-list ul {
+    list-style: none;
+    padding-left: 1rem;
+}
+
+.curriculum-nav .topic-list ul li {
+    margin-bottom: 0.75rem;
+}
+
+.curriculum-nav .topic-list ul li a {
+    font-size: 1.1rem;
+    color: var(--text-color);
+}
+
+.curriculum-nav .topic-list ul li a:hover {
+    color: var(--primary-color);
+}

--- a/topics/grammar/index.html
+++ b/topics/grammar/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Grammar - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Grammar</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>

--- a/topics/greetings/index.html
+++ b/topics/greetings/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Greetings - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Greetings</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>

--- a/topics/noun/index.html
+++ b/topics/noun/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Noun - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Noun</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>

--- a/topics/practical/index.html
+++ b/topics/practical/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Practical German - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Practical German</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>

--- a/topics/sentences/index.html
+++ b/topics/sentences/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Sentences - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Sentences</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>

--- a/topics/verb/index.html
+++ b/topics/verb/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Verb - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Verb</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>

--- a/topics/vocabulary/index.html
+++ b/topics/vocabulary/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Learn German for Myanmar Students</title>
+    <title>Vocabulary - Learn German</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../../style.css">
 </head>
 <body>
     <header>
-        <h1>Willkommen! Learn German from Scratch</h1>
+        <h1>Vocabulary</h1>
     </header>
 
-    <main style="text-align: center;">
-        <p style="font-size: 1.2rem;">Your journey to mastering the German language starts here.</p>
-        <p>We provide a comprehensive, step-by-step curriculum to guide you from your very first words to complex conversations.</p>
-        <a href="curriculum.html" class="cta-button">Start Learning</a>
+    <main>
+        <p>Lessons for this topic are coming soon.</p>
+        <br>
+        <a href="../../curriculum.html">Back to Curriculum</a>
     </main>
 
     <footer>


### PR DESCRIPTION
I have established the foundational structure for a comprehensive, multi-topic curriculum, as you requested. This is Phase 1 of the site restructure.

Key changes:
- Created a new hierarchical directory structure under `topics/` to house all future content.
- Added a new `curriculum.html` page to serve as the main table of contents for the entire curriculum.
- Created placeholder index pages for each main topic (Grammar, Noun, Verb, etc.).
- Simplified the main `index.html` to be a clean landing page with a "Start Learning" button linking to the new curriculum.
- Updated `style.css` to support the new hierarchical list layout on the curriculum page.